### PR TITLE
Pd 2692 workflow engine catch exceptions during step evaluation

### DIFF
--- a/lib/actions/parse_csv.ex
+++ b/lib/actions/parse_csv.ex
@@ -58,7 +58,7 @@ defmodule WorkflowEngine.Actions.ParseCsv do
       "tab" -> CSVTab
       "," -> CSVComma
       "comma" -> CSVComma
-      _ -> {:error, "Invalid CSV separator: #{inspect(separator)}"}
+      _ -> {:error, {:parse_csv_error, "Invalid CSV separator: #{inspect(separator)}"}}
     end
     |> OK.wrap()
   end
@@ -75,7 +75,7 @@ defmodule WorkflowEngine.Actions.ParseCsv do
   end
 
   defp get_data(_step, _state) do
-    {:error, "Missing required step parameter \"data\"."}
+    {:error, {:parse_csv_error, "Missing required step parameter \"data\"."}}
   end
 
   defp trim_bom(<<239, 187, 191, rest::binary>>) do

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -1,5 +1,5 @@
 defmodule WorkflowEngine.Error do
-  defexception [:message, :state]
+  defexception [:message, :state, :recoverable]
 
   def message(error) do
     """

--- a/lib/workflow_engine.ex
+++ b/lib/workflow_engine.ex
@@ -175,9 +175,11 @@ defmodule WorkflowEngine do
               {:ok, state}
           end
 
-        {:error, reason} ->
-          # IDEA: Some errors/error types might be allowed in the future
+        # Handle unrecoverable errors
+        {:error, {type, _message} = reason} when type in [:validation, :parse_csv_error] ->
+          wrap_error(reason, state)
 
+        {:error, reason} ->
           wrap_error(reason, state, recoverable: true)
       end
     rescue

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule WorkflowEngine.MixProject do
       {:json_logic, github: "box-id/json_logic_elixir", tag: "1.0.0", only: [:dev, :test]},
       # Same for BXDK. We could use `optional: true`, but since git tags are exact, this is not
       # a suitable way of expressing a "minimum version" requirement.
-      {:bxdk, github: "box-id/bxdk", tag: "0.24.0", only: [:dev, :test]},
+      {:bxdk, github: "box-id/bxdk", tag: "0.30.0", only: [:dev, :test]},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:mox, "~> 1.0", only: :test},
       {:bypass, "~> 2.1", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
-  "bxdk": {:git, "https://github.com/box-id/bxdk.git", "3d82bcf7683129f263816255f0082b7c2e6e605f", [tag: "0.24.0"]},
+  "bxdk": {:git, "https://github.com/box-id/bxdk.git", "9518eb2bcdaeee4dc08082c42d83941cea7219aa", [tag: "0.30.0"]},
   "bypass": {:hex, :bypass, "2.1.0", "909782781bf8e20ee86a9cabde36b259d44af8b9f38756173e8f5e2e1fabb9b1", [:mix], [{:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}, {:plug_cowboy, "~> 2.0", [hex: :plug_cowboy, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "d9b5df8fa5b7a6efa08384e9bbecfe4ce61c77d28a4282f79e02f1ef78d96b80"},
   "cachex": {:hex, :cachex, "3.6.0", "14a1bfbeee060dd9bec25a5b6f4e4691e3670ebda28c8ba2884b12fe30b36bf8", [:mix], [{:eternal, "~> 1.2", [hex: :eternal, repo: "hexpm", optional: false]}, {:jumper, "~> 1.0", [hex: :jumper, repo: "hexpm", optional: false]}, {:sleeplocks, "~> 1.1", [hex: :sleeplocks, repo: "hexpm", optional: false]}, {:unsafe, "~> 1.0", [hex: :unsafe, repo: "hexpm", optional: false]}], "hexpm", "ebf24e373883bc8e0c8d894a63bbe102ae13d918f790121f5cfe6e485cc8e2e2"},
   "castore": {:hex, :castore, "1.0.7", "b651241514e5f6956028147fe6637f7ac13802537e895a724f90bf3e36ddd1dd", [:mix], [], "hexpm", "da7785a4b0d2a021cd1292a60875a784b6caef71e76bf4917bdee1f390455cf5"},

--- a/test/actions/api_test.exs
+++ b/test/actions/api_test.exs
@@ -109,13 +109,14 @@ defmodule WorkflowEngine.Actions.ApiTest do
 
     test "returns error for error result" do
       BXDKTagsMock
-      |> expect(:get, fn _params -> {:error, "Something went wrong"} end)
+      |> expect(:get, fn _params ->
+        {:error, {:validation, %{"message" => "Something went wrong"}}}
+      end)
 
       {:error, error} =
         build_workflow("tags", "get", [1])
         |> WorkflowEngine.evaluate()
 
-      assert error.recoverable == true
       assert error.message =~ "Something went wrong"
     end
 

--- a/test/actions/api_test.exs
+++ b/test/actions/api_test.exs
@@ -12,7 +12,8 @@ defmodule WorkflowEngine.Actions.ApiTest do
         build_workflow(nil, "create", [])
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "Missing required step parameter \"entity\""
+      assert error.recoverable == false
+      assert error.message =~ "Missing required step parameter \"entity\""
     end
 
     test "fails when given nonexistent 'entity' param" do
@@ -20,7 +21,8 @@ defmodule WorkflowEngine.Actions.ApiTest do
         build_workflow("nonexistent", "create", [])
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "doesn't exist"
+      assert error.recoverable == false
+      assert error.message =~ "doesn't exist"
     end
 
     test "fails when given non-entity api module" do
@@ -28,7 +30,8 @@ defmodule WorkflowEngine.Actions.ApiTest do
         build_workflow("internal_api", "get", [])
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "not a valid BXDK API module"
+      assert error.recoverable == false
+      assert error.message =~ "not a valid BXDK API module"
     end
 
     test "fails when missing 'operation' param" do
@@ -36,7 +39,8 @@ defmodule WorkflowEngine.Actions.ApiTest do
         build_workflow("tags", nil, [])
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "Missing required step parameter \"operation\""
+      assert error.recoverable == false
+      assert error.message =~ "Missing required step parameter \"operation\""
     end
 
     test "fails when given nonexistent function" do
@@ -44,7 +48,8 @@ defmodule WorkflowEngine.Actions.ApiTest do
         build_workflow("tags", "incarcerate", [])
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "doesn't exist"
+      assert error.recoverable == false
+      assert error.message =~ "doesn't exist"
     end
 
     test "fails when missing 'args' param" do
@@ -52,7 +57,8 @@ defmodule WorkflowEngine.Actions.ApiTest do
         build_workflow("tags", "get", nil)
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "Missing required step parameter \"args\""
+      assert error.recoverable == false
+      assert error.message =~ "Missing required step parameter \"args\""
     end
 
     test "fails when calling function with wrong arity" do
@@ -60,7 +66,8 @@ defmodule WorkflowEngine.Actions.ApiTest do
         build_workflow("tags", "get", [])
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "BXDK.Tags.get/0 doesn't exist"
+      assert error.recoverable == false
+      assert error.message =~ "BXDK.Tags.get/0 doesn't exist"
     end
 
     test "fails when args logic doesn't return a list" do
@@ -68,7 +75,8 @@ defmodule WorkflowEngine.Actions.ApiTest do
         build_workflow("tags", "get", %{})
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "Args logic must return a list"
+      assert error.recoverable == false
+      assert error.message =~ "Args logic must return a list"
     end
   end
 
@@ -107,7 +115,8 @@ defmodule WorkflowEngine.Actions.ApiTest do
         build_workflow("tags", "get", [1])
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "Something went wrong"
+      assert error.recoverable == true
+      assert error.message =~ "Something went wrong"
     end
 
     test "returns error for non-existent BXDK entity" do
@@ -115,7 +124,8 @@ defmodule WorkflowEngine.Actions.ApiTest do
         build_workflow("asset", "audit", ["a1234567", true])
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "ApiAction: BXDK entity \"Asset\" doesn't exist"
+      assert error.recoverable == false
+      assert error.message =~ "ApiAction: BXDK entity \"Asset\" doesn't exist"
     end
   end
 

--- a/test/actions/api_test.exs
+++ b/test/actions/api_test.exs
@@ -4,65 +4,71 @@ defmodule WorkflowEngine.Actions.ApiTest do
 
   import Mox
 
-  alias WorkflowEngine.Error
-
   setup :verify_on_exit!
 
   describe "API Action - Call Validation" do
     test "fails when missing entity parameter" do
-      assert_raise Error, ~r/Missing required step parameter "entity"/, fn ->
+      {:error, error} =
         build_workflow(nil, "create", [])
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "Missing required step parameter \"entity\""
     end
 
     test "fails when given nonexistent 'entity' param" do
-      assert_raise Error, ~r/doesn't exist/, fn ->
+      {:error, error} =
         build_workflow("nonexistent", "create", [])
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "doesn't exist"
     end
 
     test "fails when given non-entity api module" do
-      assert_raise Error, ~r/not a valid BXDK API module/, fn ->
+      {:error, error} =
         build_workflow("internal_api", "get", [])
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "not a valid BXDK API module"
     end
 
     test "fails when missing 'operation' param" do
-      assert_raise Error, ~r/Missing required step parameter "operation"/, fn ->
+      {:error, error} =
         build_workflow("tags", nil, [])
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "Missing required step parameter \"operation\""
     end
 
     test "fails when given nonexistent function" do
-      assert_raise Error, ~r/doesn't exist/, fn ->
+      {:error, error} =
         build_workflow("tags", "incarcerate", [])
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "doesn't exist"
     end
 
     test "fails when missing 'args' param" do
-      assert_raise Error, ~r/Missing required step parameter "args"/, fn ->
+      {:error, error} =
         build_workflow("tags", "get", nil)
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "Missing required step parameter \"args\""
     end
 
     test "fails when calling function with wrong arity" do
-      assert_raise Error, ~r/BXDK\.Tags\.get\/0 doesn't exist/, fn ->
+      {:error, error} =
         build_workflow("tags", "get", [])
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "BXDK.Tags.get/0 doesn't exist"
     end
 
     test "fails when args logic doesn't return a list" do
-      assert_raise Error, ~r/Args logic must return a list/, fn ->
+      {:error, error} =
         build_workflow("tags", "get", %{})
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "Args logic must return a list"
     end
   end
 
@@ -102,6 +108,14 @@ defmodule WorkflowEngine.Actions.ApiTest do
         |> WorkflowEngine.evaluate()
 
       assert error =~ "Something went wrong"
+    end
+
+    test "returns error for non-existent BXDK entity" do
+      {:error, error} =
+        build_workflow("asset", "audit", ["a1234567", true])
+        |> WorkflowEngine.evaluate()
+
+      assert error =~ "ApiAction: BXDK entity \"Asset\" doesn't exist"
     end
   end
 

--- a/test/actions/http_test.exs
+++ b/test/actions/http_test.exs
@@ -27,7 +27,8 @@ defmodule WorkflowEngine.Actions.HTTPTest do
         build_workflow()
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "Missing required step parameter \"url\""
+      assert error.recoverable == false
+      assert error.message =~ "Missing required step parameter \"url\""
     end
 
     test "fails when given invalid 'url' param" do
@@ -35,7 +36,8 @@ defmodule WorkflowEngine.Actions.HTTPTest do
         build_workflow(%{"url" => "not a url"})
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "Invalid URL"
+      assert error.recoverable == false
+      assert error.message =~ "Invalid URL"
     end
 
     test "fails when given 'url' that is not allow-listed" do
@@ -43,7 +45,8 @@ defmodule WorkflowEngine.Actions.HTTPTest do
         build_workflow(%{"url" => "https://test.example.com"})
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "has not been explicitly allowed"
+      assert error.recoverable == false
+      assert error.message =~ "has not been explicitly allowed"
     end
 
     test "performs request against valid URL and path", %{bypass: bypass, url: url} do
@@ -91,7 +94,8 @@ defmodule WorkflowEngine.Actions.HTTPTest do
         build_workflow(%{"url" => url, "path" => %{"some" => "map"}})
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "Invalid path"
+      assert error.recoverable == false
+      assert error.message =~ "Invalid path"
     end
 
     test "defaults to / when given explicit NULL path", %{bypass: bypass, url: url} do
@@ -119,7 +123,8 @@ defmodule WorkflowEngine.Actions.HTTPTest do
         build_workflow(%{"url" => url, "headers" => "not a map"})
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "Invalid headers"
+      assert error.recoverable == false
+      assert error.message =~ "Invalid headers"
     end
 
     test "sends accept JSON header by default", %{bypass: bypass, url: url} do
@@ -227,7 +232,8 @@ defmodule WorkflowEngine.Actions.HTTPTest do
         build_workflow(%{"url" => url, "method" => "not a method"})
         |> WorkflowEngine.evaluate()
 
-      assert error =~ "Invalid HTTP method"
+      assert error.recoverable == false
+      assert error.message =~ "Invalid HTTP method"
     end
   end
 
@@ -420,8 +426,10 @@ defmodule WorkflowEngine.Actions.HTTPTest do
 
       assert log =~ "failed with status 400"
 
-      assert error =~ "bad_request"
-      assert error =~ "Something went wrong"
+      # INFO: is this supposed to be recoverable? likely not?
+      # assert error.recoverable == false
+      assert error.message =~ "bad_request"
+      assert error.message =~ "Something went wrong"
     end
 
     test "doesn't convert received Latin-1 plaintext response to utf8", %{

--- a/test/actions/http_test.exs
+++ b/test/actions/http_test.exs
@@ -426,8 +426,7 @@ defmodule WorkflowEngine.Actions.HTTPTest do
 
       assert log =~ "failed with status 400"
 
-      # INFO: is this supposed to be recoverable? likely not?
-      # assert error.recoverable == false
+      assert error.recoverable == true
       assert error.message =~ "bad_request"
       assert error.message =~ "Something went wrong"
     end

--- a/test/actions/http_test.exs
+++ b/test/actions/http_test.exs
@@ -4,8 +4,6 @@ defmodule WorkflowEngine.Actions.HTTPTest do
 
   import ExUnit.CaptureLog
 
-  alias WorkflowEngine.Error
-
   defmodule __MODULE__.JsonLogic do
     use JsonLogic.Base,
       extensions: [JsonLogic.Extensions.Obj]
@@ -25,24 +23,27 @@ defmodule WorkflowEngine.Actions.HTTPTest do
 
   describe "HTTP Action - URL Validation" do
     test "fails when missing 'url' param" do
-      assert_raise Error, ~r/Missing required step parameter "url"/, fn ->
+      {:error, error} =
         build_workflow()
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "Missing required step parameter \"url\""
     end
 
     test "fails when given invalid 'url' param" do
-      assert_raise Error, ~r/Invalid URL/, fn ->
+      {:error, error} =
         build_workflow(%{"url" => "not a url"})
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "Invalid URL"
     end
 
     test "fails when given 'url' that is not allow-listed" do
-      assert_raise Error, ~r/has not been explicitly allowed/, fn ->
+      {:error, error} =
         build_workflow(%{"url" => "https://test.example.com"})
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "has not been explicitly allowed"
     end
 
     test "performs request against valid URL and path", %{bypass: bypass, url: url} do
@@ -86,10 +87,11 @@ defmodule WorkflowEngine.Actions.HTTPTest do
     end
 
     test "fails when given invalid 'path'", %{url: url} do
-      assert_raise Error, ~r/Invalid path/, fn ->
+      {:error, error} =
         build_workflow(%{"url" => url, "path" => %{"some" => "map"}})
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "Invalid path"
     end
 
     test "defaults to / when given explicit NULL path", %{bypass: bypass, url: url} do
@@ -113,10 +115,11 @@ defmodule WorkflowEngine.Actions.HTTPTest do
 
   describe "HTTP Action - Headers" do
     test "fails when given invalid 'headers'", %{url: url} do
-      assert_raise Error, ~r/Invalid headers/, fn ->
+      {:error, error} =
         build_workflow(%{"url" => url, "headers" => "not a map"})
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "Invalid headers"
     end
 
     test "sends accept JSON header by default", %{bypass: bypass, url: url} do
@@ -220,10 +223,11 @@ defmodule WorkflowEngine.Actions.HTTPTest do
     end
 
     test "fails when given invalid 'method'", %{url: url} do
-      assert_raise Error, ~r/Invalid HTTP method/, fn ->
+      {:error, error} =
         build_workflow(%{"url" => url, "method" => "not a method"})
         |> WorkflowEngine.evaluate()
-      end
+
+      assert error =~ "Invalid HTTP method"
     end
   end
 

--- a/test/actions/parse_csv_test.exs
+++ b/test/actions/parse_csv_test.exs
@@ -247,7 +247,7 @@ defmodule WorkflowEngine.Actions.ParseCsvTest do
     end
 
     test "fails when given invalid separator" do
-      {:error, reason} =
+      {:error, error} =
         build_workflow(csv_settings: [separator: "foo"])
         |> WorkflowEngine.evaluate(
           params: %{
@@ -255,7 +255,9 @@ defmodule WorkflowEngine.Actions.ParseCsvTest do
           }
         )
 
-      assert reason =~ "Invalid CSV separator"
+      # INFO: is this supposed to be recoverable? likely not?
+      # assert error.recoverable == false
+      assert error.message =~ "Invalid CSV separator"
     end
   end
 

--- a/test/actions/parse_csv_test.exs
+++ b/test/actions/parse_csv_test.exs
@@ -255,8 +255,7 @@ defmodule WorkflowEngine.Actions.ParseCsvTest do
           }
         )
 
-      # INFO: is this supposed to be recoverable? likely not?
-      # assert error.recoverable == false
+      assert error.recoverable == false
       assert error.message =~ "Invalid CSV separator"
     end
   end

--- a/test/workflow_engine_test.exs
+++ b/test/workflow_engine_test.exs
@@ -257,7 +257,7 @@ defmodule WorkflowEngineTest do
     end
 
     test "fails with appropriate error if value is not iterable" do
-      assert_raise WorkflowEngine.Error, ~r/Loop value not iterable/, fn ->
+      {:error, error} =
         WorkflowEngine.evaluate(%{
           "steps" => [
             %{
@@ -266,13 +266,15 @@ defmodule WorkflowEngineTest do
             }
           ]
         })
-      end
+
+      assert error.recoverable == false
+      assert error.message =~ "Loop value not iterable"
     end
   end
 
   describe "actions" do
     test "fails with appropriate error if action is unknown" do
-      assert_raise WorkflowEngine.Error, ~r/Unknown action "foo"/, fn ->
+      {:error, error} =
         WorkflowEngine.evaluate(%{
           "steps" => [
             %{
@@ -281,7 +283,9 @@ defmodule WorkflowEngineTest do
             }
           ]
         })
-      end
+
+      assert error.recoverable == false
+      assert error.message =~ "Unknown action \"foo\""
     end
 
     test "allows extension by passing action map as option" do
@@ -324,8 +328,8 @@ defmodule WorkflowEngineTest do
                )
                ~> State.get_yielded()
 
-      assert error =~ "{:action, :echo_action}"
-      assert error =~ "Oops!"
+      assert Exception.message(error) =~ "{:action, :echo_action}"
+      assert Exception.message(error) =~ "Oops!"
     end
 
     test "allows storing result in variable" do


### PR DESCRIPTION
The Scanpage was having issues with invalid workflow actions ([PD-2620](https://box-id.atlassian.net/jira/software/projects/PD/boards/4/backlog?selectedIssue=PD-2620)).

After a deeper dive, I discovered that the WorkflowEngine simply raises an exception and doesn't return anything in case there is a problem in the step details (i.e. invalid entity for the API action), and traced the problem down to the action execution in `eval_step`.

There was already a written down idea of catching these exceptions and wrapping them in WorkflowEngine.Error.
I added some handling for this, as the ones from the API action were already wrapped.

Added a test for this clause too. I also had to adjust existing tests to expect and assert on an error instead of asserting raised exceptions. This shouldn't break any existing usage as nothing was returned anyway.

After implementing this, I updated my local Scanpage setup to use this branch, and it was in fact what was needed to fix the original bug:
<img width="430" alt="image" src="https://github.com/user-attachments/assets/cdb355c9-13ea-4a90-912e-924592814a4f">


[PD-2620]: https://box-id.atlassian.net/browse/PD-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ